### PR TITLE
Support text-based notebooks and apply mystnb patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-A Sphinx extension to execute Jupyter NoteBooks based on include and exclude patterns instead of only exclude patterns.
+A Sphinx extension to execute Jupyter NoteBooks (`*.ipynb`) and Text-based NoteBooks (`*.md`) based on include and exclude patterns instead of only exclude patterns.
+
+This extension also applies the `mystnb` patch from [JupyterBook-Patches](https://pypi.org/project/jupyterbook-patches/).
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = [
     { name = "Dennis den Ouden-van der Horst", email = "d.denouden-vanderhorst@tudelft.nl" }
 ]
 dependencies = [
-    "sphinx"
+    "sphinx",
+    "jupyterbook-patches>=1.12.1"
 ]
 
 requires-python = ">=3.10"

--- a/src/sphinx_nb_execution_patterns/__init__.py
+++ b/src/sphinx_nb_execution_patterns/__init__.py
@@ -3,7 +3,7 @@
 sphinx_nb_execution_patterns
 ~~~~~~~~~~~~~~~~~~~~
 
-A Sphinx extension to execute Jupyter NoteBooks based on include and exclude patterns instead of only exclude patterns.
+A Sphinx extension to execute Jupyter NoteBooks and Text-based NoteBooks based on include and exclude patterns instead of only exclude patterns.
 
 """
 
@@ -13,10 +13,26 @@ import fnmatch
 from typing import Any, Dict
 from sphinx.application import Sphinx
 from sphinx.util import logging
+from myst_nb.core.read import is_myst_markdown_notebook
+
+import jupyterbook_patches.patches.mystnb_patch as mystnb_patch
 
 logger = logging.getLogger(__name__)
 
 def setup(app: Sphinx) -> Dict[str, Any]:
+
+    # initialize mystnb_patch IF not already done
+    # check for one single (event,funtion) pair to determine this
+    init_done = False
+    event = 'source-read'
+    handler = mystnb_patch.fix_file_with_code_cells
+    for listener in app.events.listeners.get(event, []):
+        if listener.handler is handler:  # identity check
+            init_done = True
+            break
+    if not init_done:
+        patch = mystnb_patch.MySTNBPatch()
+        patch.initialize(app)
 
     app.add_config_value('nb_execution_includepatterns', [], 'env')
     app.add_config_value('nb_execution_patterns_method', 'only_include', 'env')
@@ -89,9 +105,9 @@ def process_execute_config(app: Sphinx, config: Any):
 
 def convert_includes_to_excludes(app: Sphinx, config: Any, include_patterns: list):
 
-    # get all .ipynb files in the source directory
-    nb_execution_excludepatterns = list_ipynb_files(app.confdir)
-    # remove .ipynb files that match any of the include patterns
+    # get all notebook files in the source directory
+    nb_execution_excludepatterns = list_notebook_files(app.confdir)
+    # remove notebook files that match any of the include patterns
     matchings = set()
     for include in include_patterns:
         matching = fnmatch.filter(nb_execution_excludepatterns, include)
@@ -100,8 +116,8 @@ def convert_includes_to_excludes(app: Sphinx, config: Any, include_patterns: lis
 
     return list(nb_execution_excludepatterns)
 
-def list_ipynb_files(confdir):
-    ipynb_files = []
+def list_notebook_files(confdir):
+    notebook_files = []
     for dirpath, dirnames, filenames in os.walk(confdir):
         rel_dir = os.path.relpath(dirpath, confdir)
         if rel_dir == '_build' or rel_dir.startswith('_build' + os.sep):
@@ -111,24 +127,41 @@ def list_ipynb_files(confdir):
             if fname.endswith('.ipynb'):
                 rel_path = fname if rel_dir == '.' else os.path.join(rel_dir, fname)
                 rel_path = rel_path.replace(os.sep, '/')
-                ipynb_files.append(rel_path)
-    return set(sorted(ipynb_files))
+                notebook_files.append(rel_path)
+            if fname.endswith('.md'):
+                rel_path = fname if rel_dir == '.' else os.path.join(rel_dir, fname)
+                rel_path = rel_path.replace(os.sep, '/')
+                full_path = os.path.join(dirpath, fname)
+                try:
+                    with open(full_path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                        # .md files must added be only íf it is a Text-based NoteBook
+                        if is_myst_markdown_notebook(content):
+                            notebook_files.append(rel_path)
+                        # or if the .md file contains top-level code-cells (as the mystnb_patch does resolve the missing yaml front matter)
+                        else:
+                            code_cells, _, _ = mystnb_patch._find_top_level_code_cells(content.splitlines())
+                            if code_cells:
+                                notebook_files.append(rel_path)                            
+                except:
+                    pass
+    return set(sorted(notebook_files))
 
 def convert_exclude_include_to_exclude(app: Sphinx, config: Any, exclude_patterns: list, include_patterns: list):
 
-    # get all .ipynb files in the source directory
-    ipynb_files = list_ipynb_files(app.confdir)
+    # get all notebook files in the source directory
+    notebook_files = list_notebook_files(app.confdir)
 
-    # include .ipynb files that match any of the exclude patterns
+    # include notebook files that match any of the exclude patterns
     nb_execution_excludepatterns = set()
     for exclude in exclude_patterns:
-        matching = fnmatch.filter(ipynb_files, exclude)
+        matching = fnmatch.filter(notebook_files, exclude)
         nb_execution_excludepatterns.update(matching)
 
-    # now exclude .ipynb files that match any of the include patterns
+    # now exclude notebook files that match any of the include patterns
     matchings = set()
     for include in include_patterns:
-        matching = fnmatch.filter(ipynb_files, include)
+        matching = fnmatch.filter(notebook_files, include)
         matchings.update(matching)
     nb_execution_excludepatterns.difference_update(matchings)
 
@@ -136,17 +169,17 @@ def convert_exclude_include_to_exclude(app: Sphinx, config: Any, exclude_pattern
 
 def convert_include_exclude_to_exclude(app: Sphinx, config: Any, exclude_patterns: list, include_patterns: list):
 
-    # get all .ipynb files in the source directory
-    nb_execution_excludepatterns = list_ipynb_files(app.confdir)
+    # get all notebook files in the source directory
+    nb_execution_excludepatterns = list_notebook_files(app.confdir)
 
-    # now exclude .ipynb files that match any of the include patterns
+    # now exclude notebook files that match any of the include patterns
     matchings = set()
     for include in include_patterns:
         matching = fnmatch.filter(nb_execution_excludepatterns, include)
         matchings.update(matching)
     nb_execution_excludepatterns.difference_update(matchings)
 
-    # now include .ipynb files that match any of the exclude patterns
+    # now include notebook files that match any of the exclude patterns
     nb_execution_excludepatterns.update(exclude_patterns)
 
     return list(nb_execution_excludepatterns)


### PR DESCRIPTION
Extend notebook execution to include both Jupyter (.ipynb) and text-based (.md) notebooks by detecting MyST markdown notebooks and top-level code cells. Integrate the mystnb patch from jupyterbook-patches for improved compatibility. Update documentation and dependencies to reflect these changes.

Closes #1 .